### PR TITLE
Reset the _lastViewedPosition when the data source changes

### DIFF
--- a/InfiniteScrollPlugin/Sequence.Plugins.InfiniteScroll.Droid/IncrementalAdapter.cs
+++ b/InfiniteScrollPlugin/Sequence.Plugins.InfiniteScroll.Droid/IncrementalAdapter.cs
@@ -19,7 +19,7 @@ namespace Sequence.Plugins.InfiniteScroll.Droid
 
         public override View GetView(int position, View convertView, ViewGroup parent)
         {
-            if ((position >= _maxPositionReached) && (position == _lastCount))
+            if ((position >= _maxPositionReached) && (position >= _lastCount))
             {
                 _maxPositionReached = position;
                 LoadMoreItems();
@@ -31,6 +31,8 @@ namespace Sequence.Plugins.InfiniteScroll.Droid
         protected override void SetItemsSource(IEnumerable value)
         {
             base.SetItemsSource(value);
+            _lastCount = 0;
+            _maxPositionReached = 0;
             LoadMoreItems();
         }
 

--- a/InfiniteScrollPlugin/Sequence.Plugins.InfiniteScroll.iOS/IncrementalTableViewSource.cs
+++ b/InfiniteScrollPlugin/Sequence.Plugins.InfiniteScroll.iOS/IncrementalTableViewSource.cs
@@ -30,6 +30,7 @@ namespace Sequence.Plugins.InfiniteScroll.iOS
         public void CreateBinding<TSource>(MvxViewController controller, Expression<Func<TSource, object>> sourceProperty)
         {
             controller.CreateBinding(this).To(sourceProperty).Apply();
+            _lastViewedPosition = 0;
             LoadMoreItems();
         }
 


### PR DESCRIPTION
Whenever the item source (ObservableCollection) changes, the _lastCount and _maxPositionReached should be set to 0... 
Otherwise the new ObservableCollection will not be loaded properly.
