### PR TITLE
Update signature of loading function

### DIFF
--- a/InfiniteScrollPlugin/Sequence.Plugins.InfiniteScroll/IIncrementalCollectionFactory.cs
+++ b/InfiniteScrollPlugin/Sequence.Plugins.InfiniteScroll/IIncrementalCollectionFactory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
@@ -6,7 +7,7 @@ namespace Sequence.Plugins.InfiniteScroll
 {
     public interface IIncrementalCollectionFactory
     {
-        ObservableCollection<T> GetCollection<T>(Func<int, int, Task<ObservableCollection<T>>> sourceDataFunc,
+        ObservableCollection<T> GetCollection<T>(Func<int, int, Task<IEnumerable<T>>> sourceDataFunc,
             int defaultPageSize = 10);
     }
 }

--- a/InfiniteScrollPlugin/Sequence.Plugins.InfiniteScroll/Shared/IncrementalCollection.cs
+++ b/InfiniteScrollPlugin/Sequence.Plugins.InfiniteScroll/Shared/IncrementalCollection.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
@@ -6,10 +7,10 @@ namespace Sequence.Plugins.InfiniteScroll.Shared
 {
     public class IncrementalCollection<T> : ObservableCollection<T>, ICoreSupportIncrementalLoading
     {
-        private readonly Func<int, int, Task<ObservableCollection<T>>> _sourceDataFunc;
+        private readonly Func<int, int, Task<IEnumerable<T>>> _sourceDataFunc;
         private int _defaultPageSize;
 
-        public IncrementalCollection(Func<int, int, Task<ObservableCollection<T>>> sourceDataFunc, int defaultPageSize)
+        public IncrementalCollection(Func<int, int, Task<IEnumerable<T>>> sourceDataFunc, int defaultPageSize)
         {
             _sourceDataFunc = sourceDataFunc;
             _defaultPageSize = defaultPageSize;
@@ -23,7 +24,7 @@ namespace Sequence.Plugins.InfiniteScroll.Shared
 
         public async Task LoadMoreItemsAsync()
         {
-            ObservableCollection<T> sourceData = await _sourceDataFunc(Count, _defaultPageSize);
+            var sourceData = await _sourceDataFunc(Count, _defaultPageSize);
 
             foreach (T dataItem in sourceData)
             {

--- a/InfiniteScrollPlugin/Sequence.Plugins.InfiniteScroll/Shared/IncrementalCollectionFactory.cs
+++ b/InfiniteScrollPlugin/Sequence.Plugins.InfiniteScroll/Shared/IncrementalCollectionFactory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 
@@ -6,7 +7,7 @@ namespace Sequence.Plugins.InfiniteScroll.Shared
 {
     public class IncrementalCollectionFactory : IIncrementalCollectionFactory
     {
-        public ObservableCollection<T> GetCollection<T>(Func<int, int, Task<ObservableCollection<T>>> sourceDataFunc, int defaultPageSize = 10)
+        public ObservableCollection<T> GetCollection<T>(Func<int, int, Task<IEnumerable<T>>> sourceDataFunc, int defaultPageSize = 10)
         {
             return new IncrementalCollection<T>(sourceDataFunc, defaultPageSize);
         }


### PR DESCRIPTION
The return value for the `sourceDataFunc` can be of type `IEnumerable<T>` instead of `ObservableCollection<T>`. This makes it easier for people to use the class and makes sure collections of different types don't have to be converted to `ObservableCollection<T>` before returning it as a result.